### PR TITLE
change build branch

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -4,7 +4,7 @@ name: deploy-book
 on:
   push:
     branches:
-    - jupyter_book
+    - master
     # If your git repository has the Jupyter Book within some-subfolder next to
     # unrelated files, you can make this run only if a file within that specific
     # folder has been modified.


### PR DESCRIPTION
This PR changes the `build` `branch` from `jupyter_book` to `master` in order to avoid back and forth between `branches`.